### PR TITLE
Remove Handler for Account Enumeration Attack

### DIFF
--- a/backend/handler/public_router.go
+++ b/backend/handler/public_router.go
@@ -2,11 +2,12 @@ package handler
 
 import (
 	"fmt"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/httplimit"
-	"github.com/teamhanko/hanko/backend/audit_log"
+	auditlog "github.com/teamhanko/hanko/backend/audit_log"
 	"github.com/teamhanko/hanko/backend/config"
 	"github.com/teamhanko/hanko/backend/crypto/jwk"
 	"github.com/teamhanko/hanko/backend/dto"
@@ -144,7 +145,6 @@ func NewPublicRouter(cfg *config.Config, persister persistence.Persister, promet
 	user.POST("", userHandler.Create)
 	user.GET("/:id", userHandler.Get, sessionMiddleware)
 
-	g.POST("/user", userHandler.GetUserIdByEmail)
 	g.POST("/logout", userHandler.Logout, sessionMiddleware)
 
 	if cfg.Account.AllowDeletion {


### PR DESCRIPTION
# Description

OWASP ID: WSTG-IDNT-04

Reference URL:
https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account

Account enumeration is enabled by the handler `/user` where a user email can be provided and the server provides a validation response of whether the user email exists along with other data.

# Implementation

- The server handler for the endpoint `/user` was removed
- The frontend-sdk function `getInfo` which accepts an email was removed

# Tests

Tests were removed that validated previous functionality.